### PR TITLE
Documenting 406 Error (Authentication Not Required)

### DIFF
--- a/docs/ae_auth.md
+++ b/docs/ae_auth.md
@@ -9,6 +9,8 @@ Tableau currently supports basic authentication with username and password.
 
 The username and password values that have been configured in Tableau are passed to the Analytics Extension using the HTTP headers of calls to the /evaluate method.
 
+​If the authentication requirement is turned off in the Analytics Extension but a username and password are still included in the request, the Analytics Extension will respond with a ```406``` error.
+
 On the Tableau side, Authentication is configured in Tableau Desktop via the Analytics Extensions UI: [https://help.tableau.com/current/pro/desktop/en-us/r_connection_manage.htm#configure-an-external-service-connection](https://help.tableau.com/current/pro/desktop/en-us/r_connection_manage.htm#configure-an-external-service-connection)
 
 In Server up to version 2020.1, connections with are configured for Analytics Extensions using the TSM Security command: [https://help.tableau.com/current/server/en-us/cli_security_tsm.htm#tsm_security_vizql-extsvc-ssl-enable](https://help.tableau.com/current/server/en-us/cli_security_tsm.htm#tsm_security_vizql-extsvc-ssl-enable)


### PR DESCRIPTION
Adding note to the authentication document (ae_auth.md) about the 406 error when auth is turned off but a username and password are still included in the request.